### PR TITLE
AI inspired changes to improve API usage for storing QC results

### DIFF
--- a/bro_connector/main/settings/base.py
+++ b/bro_connector/main/settings/base.py
@@ -11,11 +11,11 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 import os
-import pytz
 import platform
 from pathlib import Path
 
 import django.db.models.options as options
+import pytz
 from main.localsecret import ENV, GDAL_DLL_VERSION
 
 options.DEFAULT_NAMES = options.DEFAULT_NAMES + ("schema",)
@@ -48,6 +48,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 SECRET_KEY = "django-insecure-1b2-79o0!+@%9d6gt@7k5-8=8(r@&x-(15!o7+zo-zgwg4)gbv"
 
 ALLOWED_HOSTS = ["*"]
+
+# Optional canonical external origin used by embedded services (e.g. GWDatalens)
+# to construct absolute callback/API URLs.
+BRO_CONNECTOR_BASE_URL = None
 
 INSTALLED_APPS = [
     "jazzmin",
@@ -574,7 +578,7 @@ GRAPH_MODELS = {
     "group_models": True,
 }
 
-DATA_UPLOAD_MAX_MEMORY_SIZE = 10_485_760  # (10MB) needed for DASH APP
+DATA_UPLOAD_MAX_MEMORY_SIZE = 10_485_760 * 1.5  # (15MB) needed for DASH APP
 
 if platform.system() == "Windows":
     GDAL_LIBRARY_PATH = rf"C:\OSGeo4W\bin\gdal{GDAL_DLL_VERSION}.dll"

--- a/bro_connector/main/settings/user.py
+++ b/bro_connector/main/settings/user.py
@@ -2,19 +2,36 @@ import threading
 
 _user = threading.local()
 
+
 def set_current_user(user):
     _user.value = user
 
+
 def get_current_user():
     return getattr(_user, "value", None)
+
+
+def set_current_request(request):
+    _user.request = request
+
+
+def get_current_request():
+    return getattr(_user, "request", None)
+
 
 class CurrentUserMiddleware:
     """
     Stores request.user in thread-local storage so signals can use it.
     """
+
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
+        set_current_request(request)
         set_current_user(request.user)
-        return self.get_response(request)
+        try:
+            return self.get_response(request)
+        finally:
+            set_current_request(None)
+            set_current_user(None)

--- a/bro_connector/main/utils/gwdatalens_api.py
+++ b/bro_connector/main/utils/gwdatalens_api.py
@@ -1,0 +1,45 @@
+from urllib.parse import urljoin, urlsplit
+
+from django.conf import settings
+from django.urls import NoReverseMatch, reverse
+
+
+def _extract_origin(url: str) -> str:
+    """Return scheme://netloc from a URL-like value, or an empty string."""
+    if not url:
+        return ""
+    parsed = urlsplit(url)
+    if not parsed.scheme or not parsed.netloc:
+        return ""
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def get_measurements_update_api_url(default_path: str) -> str:
+    """Resolve the GLD measurement update endpoint for embedded GWDatalens.
+
+    Resolution order:
+    1. Named Django URL route
+    2. Provided default path fallback
+    3. Absolute host from BRO_CONNECTOR_BASE_URL setting
+    4. Absolute host from first CSRF_TRUSTED_ORIGINS entry
+
+    Returns an absolute URL when a host is available, otherwise a relative path.
+    """
+    try:
+        path = reverse("gld_api:observation-measurements-update")
+    except NoReverseMatch:
+        path = default_path
+
+    if not path.startswith("/"):
+        path = f"/{path}"
+
+    base_url = _extract_origin(getattr(settings, "BRO_CONNECTOR_BASE_URL", ""))
+    if not base_url:
+        trusted_origins = getattr(settings, "CSRF_TRUSTED_ORIGINS", []) or []
+        if trusted_origins:
+            base_url = _extract_origin(trusted_origins[0])
+
+    if not base_url:
+        return path
+
+    return urljoin(f"{base_url}/", path.lstrip("/"))

--- a/bro_connector/tests/gld/test_api_views.py
+++ b/bro_connector/tests/gld/test_api_views.py
@@ -1,7 +1,12 @@
 import pytest
 from django.urls import reverse
 from django.utils import timezone
-from gld.models import MeasurementTvp, Observation, ObservationMetadata
+from gld.models import (
+    MeasurementPointMetadata,
+    MeasurementTvp,
+    Observation,
+    ObservationMetadata,
+)
 from rest_framework.test import APIClient
 
 
@@ -92,9 +97,7 @@ def test_post_with_invalid_payload_returns_400(
 
 @pytest.mark.django_db
 def test_post_with_unknown_gld_id_returns_400(api_client, default_observation):
-    payload = _payload(
-        default_observation.groundwater_level_dossier, timezone.now()
-    )
+    payload = _payload(default_observation.groundwater_level_dossier, timezone.now())
     payload["gld_id"] = 999_999
     response = api_client.post(_url(), payload, format="json")
     assert response.status_code == 400
@@ -149,6 +152,84 @@ def test_post_updates_existing_measurement_and_metadata(
 
 
 @pytest.mark.django_db
+def test_post_creates_metadata_when_missing(
+    api_client, default_groundwater_level_dossier, default_measurement_tvp
+):
+    MeasurementTvp.objects.filter(pk=default_measurement_tvp.pk).update(
+        measurement_point_metadata=None
+    )
+
+    payload = _payload(
+        default_groundwater_level_dossier,
+        default_measurement_tvp.measurement_time,
+    )
+    response = api_client.post(_url(), payload, format="json")
+
+    assert response.status_code == 200
+    default_measurement_tvp.refresh_from_db()
+    assert default_measurement_tvp.measurement_point_metadata is not None
+    assert default_measurement_tvp.measurement_point_metadata_id is not None
+
+    metadata = MeasurementPointMetadata.objects.get(
+        pk=default_measurement_tvp.measurement_point_metadata_id
+    )
+    assert metadata.status_quality_control == "goedgekeurd"
+
+
+@pytest.mark.django_db
+def test_post_prefers_measurement_with_metadata_for_duplicate_timestamp(
+    api_client, default_groundwater_level_dossier, default_organisation
+):
+    metadata = ObservationMetadata.objects.create(
+        observation_type="reguliereMeting",
+        status="voorlopig",
+        responsible_party=default_organisation,
+    )
+    observation_with_metadata = Observation.objects.create(
+        groundwater_level_dossier=default_groundwater_level_dossier,
+        observation_metadata=metadata,
+    )
+    observation_without_metadata = Observation.objects.create(
+        groundwater_level_dossier=default_groundwater_level_dossier,
+        observation_metadata=metadata,
+    )
+
+    measurement_time = timezone.now()
+
+    tvp_with_metadata = MeasurementTvp.objects.create(
+        observation=observation_with_metadata,
+        measurement_time=measurement_time,
+        calculated_value=1.0,
+        field_value_unit="m",
+    )
+    tvp_without_metadata = MeasurementTvp.objects.create(
+        observation=observation_without_metadata,
+        measurement_time=measurement_time,
+        calculated_value=2.0,
+        field_value_unit="m",
+    )
+
+    MeasurementTvp.objects.filter(pk=tvp_without_metadata.pk).update(
+        measurement_point_metadata=None
+    )
+
+    payload = _payload(default_groundwater_level_dossier, measurement_time)
+    response = api_client.post(_url(), payload, format="json")
+
+    assert response.status_code == 200
+
+    tvp_with_metadata.refresh_from_db()
+    tvp_without_metadata.refresh_from_db()
+
+    assert tvp_with_metadata.measurement_point_metadata is not None
+    assert (
+        tvp_with_metadata.measurement_point_metadata.status_quality_control
+        == "goedgekeurd"
+    )
+    assert tvp_without_metadata.measurement_point_metadata is None
+
+
+@pytest.mark.django_db
 def test_post_reports_measurement_times_not_found(
     api_client, default_groundwater_level_dossier, default_observation
 ):
@@ -193,15 +274,45 @@ def test_post_matches_null_validatie_status_to_null_metadata_status(
 
 
 @pytest.mark.django_db
+def test_post_without_validatie_status_matches_any_metadata_status(
+    api_client, default_groundwater_level_dossier, default_organisation
+):
+    metadata = ObservationMetadata.objects.create(
+        observation_type="reguliereMeting",
+        status="voorlopig",
+        responsible_party=default_organisation,
+    )
+    observation = Observation.objects.create(
+        groundwater_level_dossier=default_groundwater_level_dossier,
+        observation_metadata=metadata,
+    )
+    tvp = MeasurementTvp.objects.create(
+        observation=observation,
+        measurement_time=timezone.now(),
+        calculated_value=1.0,
+        field_value_unit="m",
+    )
+
+    payload = _payload(
+        default_groundwater_level_dossier,
+        tvp.measurement_time,
+        calculated_value=7.5,
+    )
+    payload.pop("validatie_status")
+
+    response = api_client.post(_url(), payload, format="json")
+    assert response.status_code == 200
+    assert len(response.data["updated"]) == 1
+
+
+@pytest.mark.django_db
 def test_post_flags_observation_for_correction_when_up_to_date_in_bro(
     api_client,
     default_groundwater_level_dossier,
     default_observation,
     default_measurement_tvp,
 ):
-    Observation.objects.filter(pk=default_observation.pk).update(
-        up_to_date_in_bro=True
-    )
+    Observation.objects.filter(pk=default_observation.pk).update(up_to_date_in_bro=True)
 
     payload = _payload(
         default_groundwater_level_dossier, default_measurement_tvp.measurement_time

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ numpy==2.0.1
 packaging==24.0
 pandas==2.2.2
 paramiko==3.4.0
-pastas
+pastas<2.0.0
 pastastore>=1.11.0
 plotly==6.0.1
 polars


### PR DESCRIPTION
- allow getting username/password from session
- resolve url dynamically?


@jzitman No idea if these changes make sense. I asked AI to help me resolve the API endpoint URL dynamically, so it doesn't need to be hardcoded somewhere, and also to give access to the session so username and password don't have to be stored in plaintext when sending data to the API endpoint. 

Be critiical before merging this, and check carefully if these changes make sense. Otherwise feel free to tell me what the right way would be to do this. 